### PR TITLE
SpellWatchers: use spec id instead of spec name

### DIFF
--- a/config/SpellWatchers/DeathKnight.lua
+++ b/config/SpellWatchers/DeathKnight.lua
@@ -3,10 +3,10 @@ local _, ns = ...
 local watchers = ns.watchers
 
 watchers.DEATHKNIGHT = {
-  Blood = {},
-  Frost = {
+  [250] = {},
+  [251] = {
     [1] = {spellID = 196770}, -- Remorseless Winter
     [2] = {spellID = 51271} -- Pillar of Frost
   },
-  Unholy = {}
+  [252] = {}
 }

--- a/config/SpellWatchers/Druid.lua
+++ b/config/SpellWatchers/Druid.lua
@@ -3,14 +3,14 @@ local _, ns = ...
 local watchers = ns.watchers
 
 watchers.DRUID = {
-  Balance = {
+  [102] = {
     [1] = {spellID = 190984, auraID = 48517, glow = {type = "button"}}, -- Wrath / Eclipse
     [2] = {spellID = 194153, auraID = 48518, glow = {type = "button"}}, -- Starfire / Eclipse
     [3] = {spellID = 78674, glow = {type = "pixel"}}, -- Starsurge
     [4] = {spellID = 191034, glow = {type = "pixel"}}, -- Starfall
     [5] = {spellID = 78675} -- Solar Beam
   },
-  Feral = {},
-  Guardian = {},
-  Restoration = {}
+  [103] = {},
+  [104] = {},
+  [105] = {}
 }

--- a/config/SpellWatchers/Priest.lua
+++ b/config/SpellWatchers/Priest.lua
@@ -3,9 +3,9 @@ local _, ns = ...
 local watchers = ns.watchers
 
 watchers.PRIEST = {
-  Discipline = {},
-  Holy = {},
-  Shadow = {
+  [256] = {},
+  [65] = {},
+  [258] = {
     [1] = {spellID = 8092, auraID = 341207, glow = {type = "button"}}, -- Mind Blast / Dark Thought
     [2] = {spellID = 335467, glow = {type = "pixel"}}, -- Devouring Plague
     [3] = {spellID = 32379}, -- Shadow Word: Death

--- a/config/SpellWatchers/Rogue.lua
+++ b/config/SpellWatchers/Rogue.lua
@@ -3,13 +3,13 @@ local _, ns = ...
 local watchers = ns.watchers
 
 watchers.ROGUE = {
-  Assassination = {
+  [259] = {
     [1] = {spellID = 1329}, -- Mutilate
     [2] = {spellID = 703}, -- Garrote
     [3] = {spellID = 8676, auraID = 121153, glow = {type = "button"}} -- Ambush / Blindside
   },
-  Outlaw = {},
-  Subtlety = {
+  [260] = {},
+  [261] = {
     [1] = {spellID = 212283}, -- Symbols of Death
     [2] = {spellID = 185313, glow = {type = "pixel"}}, -- Shadow Dance
     [3] = {spellID = 121471}, -- Shadow Blades

--- a/config/SpellWatchers/Shaman.lua
+++ b/config/SpellWatchers/Shaman.lua
@@ -3,10 +3,10 @@ local _, ns = ...
 local watchers = ns.watchers
 
 watchers.SHAMAN = {
-  Elemental = {},
-  Enhancement = {
+  [262] = {},
+  [263] = {
     [1] = {spellID = 17364}, -- Stormstrike
     [2] = {spellID = 60103} -- Lava Lash
   },
-  Restoration = {}
+  [105] = {}
 }

--- a/config/SpellWatchers/Warlock.lua
+++ b/config/SpellWatchers/Warlock.lua
@@ -3,9 +3,9 @@ local _, ns = ...
 local watchers = ns.watchers
 
 watchers.WARLOCK = {
-  Affliction = {},
-  Demonology = {},
-  Destruction = {
+  [265] = {},
+  [266] = {},
+  [267] = {
     [1] = {spellID = 17962, glow = {type = "pixel"}}, -- Conflagrate
     [2] = {spellID = 116858, glow = {type = "pixel"}} -- Chaos Bolt
   },

--- a/elements/spellwatchers.lua
+++ b/elements/spellwatchers.lua
@@ -17,7 +17,7 @@ local _, PlayerClass = UnitClass("player")
 local pixelGlowConfig = {api:RaidColor("player"), 10, 0.25, 6, 1, -5, -5}
 
 local function UpdateSpec(element)
-  local PlayerSpec = api:GetCurrentSpecName()
+  local PlayerSpec = select(1, GetSpecializationInfo(GetSpecialization()))
   element.__spells = element.spells[PlayerClass][PlayerSpec]
 end
 


### PR DESCRIPTION
Fix #17 