### PR TITLE
Use separate font for player names

### DIFF
--- a/config/defaults.lua
+++ b/config/defaults.lua
@@ -10,6 +10,7 @@ ns.m = m
 
 m.fonts = {
     font = "Interface\\AddOns\\oUF_lumen\\media\\font.ttf",
+    mlang = "Interface\\AddOns\\oUF_lumen\\media\\font.ttf",
     symbols = "Interface\\AddOns\\oUF_lumen\\media\\symbols.otf",
     symbols_light = "Interface\\AddOns\\oUF_lumen\\media\\symbols_light.otf"
 }

--- a/elements/blizzard.lua
+++ b/elements/blizzard.lua
@@ -3,8 +3,6 @@ local _, ns = ...
 local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 
-local font = m.fonts.font
-
 local _G = _G
 
 -- -----------------------------------------
@@ -53,7 +51,7 @@ function lum:MirrorBars()
         bg:SetTexture(m.textures.bg_texture)
         bg:SetColorTexture(0.2, 0.2, 0.2)
 
-        text:SetFont(font, cfg.fontsize - 1, "THINOUTLINE")
+        text:SetFont(m.fonts.font, cfg.fontsize - 1, "THINOUTLINE")
         text:ClearAllPoints()
         text:SetPoint("LEFT", statusBar, 4, 0)
         mirrorTimer.label = text

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -3,7 +3,6 @@ local _, ns = ...
 local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 
-local font = m.fonts.font
 local format = string.format
 
 -- ------------------------------------------------------------------------
@@ -125,7 +124,7 @@ function lum:CreateCastbar(self)
     local Max = Castbar:CreateFontString(nil, "BACKGROUND")
     Max:SetTextColor(100 / 255, 100 / 255, 100 / 255)
     Max:SetJustifyH("RIGHT")
-    Max:SetFont(font, cfg.fontsize - 2, "THINOUTLINE")
+    Max:SetFont(m.fonts.font, cfg.fontsize - 2, "THINOUTLINE")
     Max:SetPoint("RIGHT", Time, "LEFT", 0, 0)
     Castbar.Max = Max
 
@@ -142,11 +141,11 @@ function lum:CreateCastbar(self)
                          cfg.units.player.castbar.pos.x,
                          cfg.units.player.castbar.pos.y)
 
-        Text:SetFont(font, cfg.fontsize + 1, "THINOUTLINE")
+        Text:SetFont(m.fonts.font, cfg.fontsize + 1, "THINOUTLINE")
         Text:SetWidth(cfg.units.player.castbar.width - 60)
         Text:SetPoint("LEFT", Castbar, 4, 0)
 
-        Time:SetFont(font, cfg.fontsize + 1, "THINOUTLINE")
+        Time:SetFont(m.fonts.font, cfg.fontsize + 1, "THINOUTLINE")
         Time:SetPoint("RIGHT", Castbar, -6, 0)
 
         Icon:SetHeight(cfg.units.player.castbar.height)
@@ -170,11 +169,11 @@ function lum:CreateCastbar(self)
         Castbar:SetHeight(cfg.units.target.castbar.height)
         Castbar:SetPoint("CENTER", "UIParent", "CENTER", 0, 320)
 
-        Text:SetFont(font, cfg.fontsize + 1, "THINOUTLINE")
+        Text:SetFont(m.fonts.font, cfg.fontsize + 1, "THINOUTLINE")
         Text:SetWidth(cfg.units.target.castbar.width - 60)
         Text:SetPoint("LEFT", Castbar, 6, 0)
 
-        Time:SetFont(font, cfg.fontsize + 1, "THINOUTLINE")
+        Time:SetFont(m.fonts.font, cfg.fontsize + 1, "THINOUTLINE")
         Time:SetPoint("RIGHT", Castbar, -6, 0)
 
         Icon:SetHeight(cfg.units.target.castbar.height)
@@ -188,11 +187,11 @@ function lum:CreateCastbar(self)
         Castbar:SetHeight(cfg.units.focus.castbar.height)
         Castbar:SetPoint("CENTER", "UIParent", "CENTER", 0, 280)
 
-        Text:SetFont(font, cfg.fontsize + 1, "THINOUTLINE")
+        Text:SetFont(m.fonts.font, cfg.fontsize + 1, "THINOUTLINE")
         Text:SetWidth(cfg.units.focus.castbar.width - 60)
         Text:SetPoint("LEFT", Castbar, 4, 0)
 
-        Time:SetFont(font, cfg.fontsize, "THINOUTLINE")
+        Time:SetFont(m.fonts.font, cfg.fontsize, "THINOUTLINE")
         Time:SetPoint("RIGHT", Castbar, -6, 0)
 
         Icon:SetHeight(cfg.units.focus.castbar.height)
@@ -207,11 +206,11 @@ function lum:CreateCastbar(self)
         Castbar:SetPoint("TOPLEFT", self, 0, 0)
         Castbar:SetPoint("BOTTOMRIGHT", self, 0, 0)
 
-        Text:SetFont(font, cfg.fontsize + 1, "THINOUTLINE")
+        Text:SetFont(m.fonts.font, cfg.fontsize + 1, "THINOUTLINE")
         Text:SetWidth(cfg.units.boss.width - 50)
         Text:SetPoint("LEFT", Castbar, 4, 0)
 
-        Time:SetFont(font, cfg.fontsize, "THINOUTLINE")
+        Time:SetFont(m.fonts.font, cfg.fontsize, "THINOUTLINE")
         Time:SetPoint("RIGHT", Castbar, -6, 0)
 
         Icon:SetHeight(cfg.units.boss.height)
@@ -224,11 +223,11 @@ function lum:CreateCastbar(self)
         Castbar:SetHeight(cfg.units.nameplate.castbar.height)
         Castbar:SetPoint("TOPLEFT", self.Health, "BOTTOMLEFT", 0, -5)
 
-        Text:SetFont(font, cfg.fontsize - 5, "THINOUTLINE")
+        Text:SetFont(m.fonts.font, cfg.fontsize - 5, "THINOUTLINE")
         Text:SetWidth(cfg.units.nameplate.width - 4)
         Text:SetPoint("CENTER", Castbar, -2, -10)
 
-        Time:SetFont(font, cfg.fontsize - 6, "THINOUTLINE")
+        Time:SetFont(m.fonts.font, cfg.fontsize - 6, "THINOUTLINE")
         Time:SetPoint("RIGHT", Castbar, 2, -10)
         Time:SetTextColor(.7, .7, .7)
 

--- a/functions.lua
+++ b/functions.lua
@@ -6,8 +6,6 @@ local filters, debuffs, watchers = ns.filters, ns.debuffs, ns.watchers
 
 local UnitAura, UnitPowerType = UnitAura, UnitPowerType
 
-local font = m.fonts.font
-
 -- -----------------------------------
 -- > Health bar
 -- -----------------------------------
@@ -276,7 +274,7 @@ function lum:CreateAdditionalPower(self)
     bg:SetTexture(m.textures.bg_texture)
     bg:SetVertexColor(r * 0.25, g * 0.25, b * 0.25)
 
-    local PowerValue = api:CreateFontstring(AdditionalPower, font,
+    local PowerValue = api:CreateFontstring(AdditionalPower, m.fonts.font,
                                             cfg.fontsize - 3, "THINOUTLINE")
     PowerValue:SetPoint("CENTER", AdditionalPower, 0, 0)
     PowerValue:SetJustifyH("CENTER")
@@ -793,7 +791,7 @@ function lum:CreateAlternativePower(self)
         AlternativePower:SetWidth(200)
         AlternativePower:SetPoint("CENTER", "UIParent", "CENTER", 0, 350)
 
-        AlternativePower.Text = api:CreateFontstring(AlternativePower, font, 10,
+        AlternativePower.Text = api:CreateFontstring(AlternativePower, m.fonts.font, 10,
                                                      "THINOUTLINE")
         AlternativePower.Text:SetPoint("CENTER", 0, 0)
 
@@ -828,7 +826,7 @@ function lum:CreatePlayerIconIndicators(self)
 
     -- Resting
     if not api:IsPlayerMaxLevel() then
-        local Resting = api:CreateFontstring(self.Health, font,
+        local Resting = api:CreateFontstring(self.Health, m.fonts.font,
                                              cfg.fontsize - 2, "THINOUTLINE")
         Resting:SetPoint("CENTER", self.Health, "TOP", 0, 1)
         Resting:SetText("zZz")

--- a/shared.lua
+++ b/shared.lua
@@ -8,8 +8,6 @@ local _, ns = ...
 local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 
-local font = m.fonts.font
-
 -- -----------------------------------
 -- > Shared Style Function
 -- -----------------------------------

--- a/units/arena.lua
+++ b/units/arena.lua
@@ -3,8 +3,6 @@ local A, ns = ...
 local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 
-local font = m.fonts.font
-
 local frame = "arena"
 
 -- -----------------------------------
@@ -20,15 +18,15 @@ local function CreateArena(self)
     self:SetSize(self.cfg.width, self.cfg.height)
 
     -- Texts
-    lum:CreateNameString(self, font, cfg.fontsize + 2, "THINOUTLINE", 4, 0,
+    lum:CreateNameString(self, m.fonts.mlang, cfg.fontsize + 2, "THINOUTLINE", 4, 0,
                          "LEFT", self.cfg.width - 75)
     self:Tag(self.Name, "[lum:level]  [lum:name]")
-    lum:CreateHealthValueString(self, font, cfg.fontsize, "THINOUTLINE", -4, 0,
+    lum:CreateHealthValueString(self, m.fonts.font, cfg.fontsize, "THINOUTLINE", -4, 0,
                                 "RIGHT")
     self:Tag(self.Health.value, "[lum:hpvalue]")
-    lum:CreateHealthPercentString(self, font, cfg.fontsize, nil, -32, 0, "LEFT",
+    lum:CreateHealthPercentString(self, m.fonts.font, cfg.fontsize, nil, -32, 0, "LEFT",
                                   "BACKGROUND")
-    lum:CreatePowerValueString(self, font, cfg.fontsize - 4, "THINOUTLINE", 0,
+    lum:CreatePowerValueString(self, m.fonts.font, cfg.fontsize - 4, "THINOUTLINE", 0,
                                0, "CENTER")
 
     lum:CreateCastbar(self)

--- a/units/boss.lua
+++ b/units/boss.lua
@@ -4,8 +4,6 @@ local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 local filters = ns.filters
 
-local font = m.fonts.font
-
 local frame = "boss"
 
 -- -----------------------------------
@@ -21,13 +19,13 @@ local function CreateBoss(self)
     self:SetSize(self.cfg.width, self.cfg.height)
 
     -- Texts
-    lum:CreateNameString(self, font, cfg.fontsize + 2, "THINOUTLINE", 4, 0,
+    lum:CreateNameString(self, m.fonts.mlang, cfg.fontsize + 2, "THINOUTLINE", 4, 0,
                          "LEFT", self.cfg.width - 60)
-    lum:CreateHealthValueString(self, font, cfg.fontsize, "THINOUTLINE", -4, 0,
+    lum:CreateHealthValueString(self, m.fonts.font, cfg.fontsize, "THINOUTLINE", -4, 0,
                                 "RIGHT")
-    lum:CreateHealthPercentString(self, font, cfg.fontsize, nil, -32, 0, "LEFT",
+    lum:CreateHealthPercentString(self, m.fonts.font, cfg.fontsize, nil, -32, 0, "LEFT",
                                   "BACKGROUND")
-    lum:CreatePowerValueString(self, font, cfg.fontsize - 4, "THINOUTLINE", 0,
+    lum:CreatePowerValueString(self, m.fonts.font, cfg.fontsize - 4, "THINOUTLINE", 0,
                                0, "CENTER")
 
     -- Auras

--- a/units/focus.lua
+++ b/units/focus.lua
@@ -3,8 +3,6 @@ local A, ns = ...
 local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 
-local font = m.fonts.font
-
 local frame = "focus"
 
 -- ------------------------------------------------------------------------
@@ -38,7 +36,7 @@ local function CreateFocus(self)
     lum:SharedStyle(self, "secondary")
 
     -- Texts
-    lum:CreateNameString(self, font, cfg.fontsize - 2, "THINOUTLINE", 3, 0,
+    lum:CreateNameString(self, m.fonts.mlang, cfg.fontsize - 2, "THINOUTLINE", 3, 0,
                          "LEFT", self.cfg.width - 4)
     self:Tag(self.Name, "[lum:name]")
 

--- a/units/nameplates.lua
+++ b/units/nameplates.lua
@@ -7,8 +7,6 @@ local _G = _G
 
 local UnitIsPlayer, UnitIsUnit = UnitIsPlayer, UnitIsUnit
 
-local font = m.fonts.font
-
 local frame = "nameplate"
 
 -- -----------------------------------
@@ -150,7 +148,7 @@ local PostUpdatePlates = function(self, event, unit)
     end
 
     if not self.isPlayer then
-        lum:CreateNameString(self, font, cfg.fontsize - 5, "THINOUTLINE", 0, 4,
+        lum:CreateNameString(self, m.fonts.mlang, cfg.fontsize - 5, "THINOUTLINE", 0, 4,
                              "CENTER", self.cfg.width - 4)
         self:Tag(self.Name, "[lum:levelplus] [lum:name]")
     end
@@ -158,7 +156,7 @@ end
 
 local function CreateNameplateClassPower(self)
     if cfg.units.nameplate.classpower.show then
-        classPower = api:CreateFontstring(self.Health, font, cfg.fontsize - 2,
+        classPower = api:CreateFontstring(self.Health, m.fonts.font, cfg.fontsize - 2,
                                           "THINOUTLINE", "BACKGROUND")
         classPower:SetPoint("RIGHT", self.Health, "LEFT", -4, 0)
         classPower:SetJustifyH("RIGHT")
@@ -192,7 +190,7 @@ local function CreateNameplate(self, unit)
 
     local health = lum:CreateHealthBar(self, "nameplate")
     health:SetAllPoints()
-    health.percent = api:CreateFontstring(self.Health, font, cfg.fontsize - 4,
+    health.percent = api:CreateFontstring(self.Health, m.fonts.font, cfg.fontsize - 4,
                                           "THINOUTLINE", "BACKGROUND")
     health.percent:SetPoint("LEFT", self.Health, "RIGHT", 4, 0)
     health.percent:SetJustifyH("LEFT")

--- a/units/party.lua
+++ b/units/party.lua
@@ -4,8 +4,6 @@ local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 local filters, debuffs = ns.filters, ns.debuffs
 
-local font = m.fonts.font
-
 local frame = "party"
 
 -- -----------------------------------
@@ -105,16 +103,16 @@ local function CreateParty(self)
     self.Power.PostUpdate = PostUpdatePower
 
     -- Texts
-    lum:CreateHealthValueString(self, font, cfg.fontsize - 2, "THINOUTLINE", 4,
+    lum:CreateHealthValueString(self, m.fonts.font, cfg.fontsize - 2, "THINOUTLINE", 4,
                                 8, "LEFT")
-    lum:CreatePartyNameString(self, font, cfg.fontsize)
+    lum:CreatePartyNameString(self, m.fonts.mlang, cfg.fontsize)
 
     if self.cfg.health.classColoredText then
         self:Tag(self.Name,
                  "[lum:playerstatus] [lum:leader] [raidcolor][lum:name]")
     end
 
-    self.classText = api:CreateFontstring(self.Health, font, cfg.fontsize,
+    self.classText = api:CreateFontstring(self.Health, m.fonts.font, cfg.fontsize,
                                           "THINOUTLINE")
     self.classText:SetPoint("BOTTOMRIGHT", self, "BOTTOMRIGHT", -4, 5)
     self.classText:SetJustifyH("RIGHT")

--- a/units/pet.lua
+++ b/units/pet.lua
@@ -4,8 +4,6 @@ local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 local filters = ns.filters
 
-local font = m.fonts.font
-
 local frame = "pet"
 
 -- -----------------------------------
@@ -27,7 +25,7 @@ local function CreatePet(self)
     lum:SharedStyle(self, "secondary")
 
     -- Texts
-    lum:CreateNameString(self, font, cfg.fontsize - 2, "THINOUTLINE", 3, 0,
+    lum:CreateNameString(self, m.fonts.mlang, cfg.fontsize - 2, "THINOUTLINE", 3, 0,
                          "LEFT", self.cfg.width - 8)
     self:Tag(self.Name, "[lum:name]")
 

--- a/units/player.lua
+++ b/units/player.lua
@@ -4,8 +4,6 @@ local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 local filters = ns.filters
 
-local font = m.fonts.font
-
 local frame = "player"
 
 -- -----------------------------------
@@ -19,13 +17,13 @@ local function CreatePlayer(self)
     lum:SharedStyle(self, "main")
 
     -- Text strings
-    lum:CreateNameString(self, font, cfg.fontsize, "THINOUTLINE", 4, -0.5,
+    lum:CreateNameString(self, m.fonts.mlang, cfg.fontsize, "THINOUTLINE", 4, -0.5,
                          "LEFT", self.cfg.width - 56)
-    lum:CreateHealthValueString(self, font, cfg.fontsize, "THINOUTLINE", -4,
+    lum:CreateHealthValueString(self, m.fonts.font, cfg.fontsize, "THINOUTLINE", -4,
                                 -0.5, "RIGHT")
-    lum:CreateHealthPercentString(self, font, cfg.fontsize, nil, -32, -0.5,
+    lum:CreateHealthPercentString(self, m.fonts.font, cfg.fontsize, nil, -32, -0.5,
                                   "LEFT", "BACKGROUND")
-    lum:CreatePowerValueString(self, font, cfg.fontsize - 3, "THINOUTLINE", 0,
+    lum:CreatePowerValueString(self, m.fonts.font, cfg.fontsize - 3, "THINOUTLINE", 0,
                                0, "CENTER")
 
     lum:CreateCastbar(self)

--- a/units/playerplate.lua
+++ b/units/playerplate.lua
@@ -3,8 +3,6 @@ local A, ns = ...
 local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 
-local font = m.fonts.font
-
 local frame = "playerplate"
 local frameName = A .. "PlayerPlate"
 
@@ -30,7 +28,7 @@ local function CreatePlayerPlate(self, unit)
 
     local power = lum:CreatePowerBar(self, "nameplate")
     power:SetAllPoints(self)
-    lum:CreatePowerValueString(self, font, cfg.fontsize - 2, "THINOUTLINE", 0,
+    lum:CreatePowerValueString(self, m.fonts.font, cfg.fontsize - 2, "THINOUTLINE", 0,
                                0, "CENTER")
 
     lum:CreateClassPower(self)

--- a/units/target.lua
+++ b/units/target.lua
@@ -4,8 +4,6 @@ local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m,
                                        ns.G, ns.oUF
 local filters = ns.filters
 
-local font = m.fonts.font
-
 local frame = "target"
 
 -- -----------------------------------
@@ -19,15 +17,15 @@ local function CreateTarget(self)
     lum:SharedStyle(self, "main")
 
     -- Texts
-    lum:CreateNameString(self, font, cfg.fontsize, "THINOUTLINE", 4, -0.5,
+    lum:CreateNameString(self, m.fonts.mlang, cfg.fontsize, "THINOUTLINE", 4, -0.5,
                          "LEFT", self.cfg.width - 56)
-    lum:CreateHealthValueString(self, font, cfg.fontsize, "THINOUTLINE", -4,
+    lum:CreateHealthValueString(self, m.fonts.font, cfg.fontsize, "THINOUTLINE", -4,
                                 -0.5, "RIGHT")
-    lum:CreateHealthPercentString(self, font, cfg.fontsize, nil, -32, -0.5,
+    lum:CreateHealthPercentString(self, m.fonts.font, cfg.fontsize, nil, -32, -0.5,
                                   "LEFT", "BACKGROUND")
-    lum:CreatePowerValueString(self, font, cfg.fontsize - 3, "THINOUTLINE", 0,
+    lum:CreatePowerValueString(self, m.fonts.font, cfg.fontsize - 3, "THINOUTLINE", 0,
                                0, "CENTER")
-    lum:CreateClassificationString(self, font, cfg.fontsize - 1)
+    lum:CreateClassificationString(self, m.fonts.font, cfg.fontsize - 1)
 
     lum:CreateCastbar(self)
     lum:CreateHealPrediction(self)

--- a/units/targettarget.lua
+++ b/units/targettarget.lua
@@ -2,8 +2,6 @@ local A, ns = ...
 
 local lum, core, api, cfg, m, G, oUF = ns.lum, ns.core, ns.api, ns.cfg, ns.m, ns.G, ns.oUF
 
-local font = m.fonts.font
-
 local frame = "targettarget"
 
 -- ------------------------------------------------------------------------
@@ -36,7 +34,7 @@ local function CreateTargetTarget(self)
   lum:SharedStyle(self, "secondary")
 
   -- Texts
-  lum:CreateNameString(self, font, cfg.fontsize - 2, "THINOUTLINE", 3, 0, "LEFT", self.cfg.width - 4)
+  lum:CreateNameString(self, m.fonts.mlang, cfg.fontsize - 2, "THINOUTLINE", 3, 0, "LEFT", self.cfg.width - 4)
   self:Tag(self.Name, "[lum:name]")
 
   -- Health & Power Updates


### PR DESCRIPTION
Player may use Chinese or Japanese characters for their name, the default font doesn't contain these glyphs, so a separate font setting is preferred for player names.